### PR TITLE
Slash fix

### DIFF
--- a/src/DisplayFrames.hs
+++ b/src/DisplayFrames.hs
@@ -7,7 +7,7 @@ import Displayable
 import Frames
 import Data.Vinyl.TypeLevel (RecAll)
 import Text.Blaze.Html5 (toHtml, td, tr)
-import Text.Blaze.Html.Renderer.Text (renderHtml)
+import Text.Blaze.Html.Renderer.Pretty (renderHtml)
 import Data.Text.Lazy (toChunks)
 import qualified Data.Vinyl.Functor as V
 import qualified Data.Text as T

--- a/src/DisplayFrames.hs
+++ b/src/DisplayFrames.hs
@@ -6,14 +6,15 @@ import DisplayTypes
 import Displayable
 import Frames
 import Data.Vinyl.TypeLevel (RecAll)
-import Text.Blaze.Html5 (toHtml)
+import Text.Blaze.Html5 (toHtml, td, tr)
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 import Data.Text.Lazy (toChunks)
 import qualified Data.Vinyl.Functor as V
 import qualified Data.Text as T
 
 -- instance of Displayable of Record from Frames package
-instance (RecAll V.Identity r Show, ColumnHeaders r, AsVinyl r) => Displayable (Record r) where
+instance (RecAll V.Identity (UnColumn r) Show, ColumnHeaders r, AsVinyl r) => Displayable (Record r) where
   display rec = Display DisplayHtml html 
     where 
-      html = (T.unpack . T.concat . toChunks . renderHtml) (toHtml $ show rec)
+      html = renderHtml $ toTable $ showFields rec
+      toTable = tr . mapM_ (td . toHtml)

--- a/src/DisplayFrames.hs
+++ b/src/DisplayFrames.hs
@@ -2,6 +2,7 @@
 
 module DisplayFrames where 
 
+import Control.Monad (mapM_)
 import DisplayTypes
 import Displayable
 import Frames

--- a/src/DisplayTypes.hs
+++ b/src/DisplayTypes.hs
@@ -43,4 +43,5 @@ instance FromJSON Display
 -- Allows arbitrart Display types to be printed in the console
 -- JSON was chosen for an easy format for the front-end of HaskellDO to parse
 instance Show Display where
-  show = T.unpack . T.stripStart . T.pack . show . toEncoding
+  show (Display DisplayList lst) = lst 
+  show d = show $ toEncoding $ content d 

--- a/src/DisplayTypes.hs
+++ b/src/DisplayTypes.hs
@@ -44,4 +44,4 @@ instance FromJSON Display
 -- JSON was chosen for an easy format for the front-end of HaskellDO to parse
 instance Show Display where
   show (Display DisplayList lst) = lst 
-  show d = show $ toEncoding $ content d 
+  show d = T.unpack $ T.stripStart $ T.pack $ show $ toEncoding d


### PR DESCRIPTION
Fixed odd number of slashes appearing when displaying lists, the issue stemmed from essentially reshowing a list which had already had show called on it.